### PR TITLE
Add private npm registry support

### DIFF
--- a/app/Enums/NpmPackageVersionStatus.php
+++ b/app/Enums/NpmPackageVersionStatus.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enums;
+
+enum NpmPackageVersionStatus: string
+{
+    case DRAFT = 'draft';
+    case READY = 'ready';
+}

--- a/app/Enums/NpmPackageVersionType.php
+++ b/app/Enums/NpmPackageVersionType.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Enums;
+
+use Illuminate\Support\Str;
+
+enum NpmPackageVersionType: string
+{
+    case DEV = 'dev';
+    case STABLE = 'stable';
+
+    public static function fromRoute(?string $routeParam): NpmPackageVersionType
+    {
+        if (Str::contains($routeParam, 'dev')) {
+            return self::DEV;
+        }
+
+        return self::STABLE;
+    }
+}

--- a/app/Http/Controllers/Npm/NpmPackageController.php
+++ b/app/Http/Controllers/Npm/NpmPackageController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Http\Controllers\Npm;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Npm\NpmPackageCollection;
+use App\Models\NpmPackage;
+
+class NpmPackageController extends Controller
+{
+    public function index(): NpmPackageCollection
+    {
+        return NpmPackageCollection::make(NpmPackage::query()->get());
+    }
+}

--- a/app/Http/Controllers/Npm/NpmPackageVersionController.php
+++ b/app/Http/Controllers/Npm/NpmPackageVersionController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Controllers\Npm;
+
+use App\Enums\NpmPackageVersionType;
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Npm\NpmPackageVersionCollection;
+use App\Models\NpmPackage;
+
+class NpmPackageVersionController extends Controller
+{
+    public function index(NpmPackage $npmPackage, $dev = null): NpmPackageVersionCollection
+    {
+        $packageVersions = $npmPackage
+            ->npmPackageVersions()
+            ->with('npmPackage')
+            ->where('version_type', '=', NpmPackageVersionType::fromRoute($dev))
+            ->orderBy('version_code', 'desc')
+            ->get();
+
+        return NpmPackageVersionCollection::make($packageVersions);
+    }
+}

--- a/app/Http/Controllers/Npm/NpmPackageVersionDownloadController.php
+++ b/app/Http/Controllers/Npm/NpmPackageVersionDownloadController.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Controllers\Npm;
+
+use App\Http\Controllers\Controller;
+use App\Models\NpmPackage;
+use App\Models\NpmPackageVersion;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class NpmPackageVersionDownloadController extends Controller
+{
+    public function __invoke(
+        NpmPackage $npmPackage,
+        NpmPackageVersion $npmPackageVersion,
+    ): StreamedResponse|JsonResponse|Response {
+        if (!Storage::exists($npmPackageVersion->storage_path)) {
+            return response()->json([
+                'error' => 'Package version dist not found',
+            ], 404);
+        }
+
+        $file_name = Str::afterLast($npmPackageVersion->storage_path, '/');
+
+        $headers = [
+            'Content-Type' => Storage::mimeType($npmPackageVersion->storage_path),
+            'Content-Disposition' => 'attachment; filename="' . $file_name . '"',
+        ];
+
+        return \Response::make(Storage::get($npmPackageVersion->storage_path), 200, $headers);
+    }
+}

--- a/app/Http/Resources/Npm/NpmPackageCollection.php
+++ b/app/Http/Resources/Npm/NpmPackageCollection.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Resources\Npm;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+class NpmPackageCollection extends ResourceCollection
+{
+    public $collection;
+
+    public static $wrap = null;
+
+    public function toArray(Request $request): array
+    {
+        return [
+            'packages' => [],
+            'metadata-url' => config('app.url') . route('npm.npmPackage.show', ['%package%'], false),
+            'available-packages' => $this->collection->pluck('name'),
+        ];
+    }
+}

--- a/app/Http/Resources/Npm/NpmPackageVersionCollection.php
+++ b/app/Http/Resources/Npm/NpmPackageVersionCollection.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Resources\Npm;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+class NpmPackageVersionCollection extends ResourceCollection
+{
+    public $collection;
+
+    public static $wrap = null;
+
+    public function toArray(Request $request): array
+    {
+        $packageName = $this->collection->first()?->npmPackage?->name;
+
+        return [
+            'packages' => [
+                $packageName => NpmPackageVersionResource::collection($this->collection),
+            ],
+        ];
+    }
+}

--- a/app/Http/Resources/Npm/NpmPackageVersionResource.php
+++ b/app/Http/Resources/Npm/NpmPackageVersionResource.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Resources\Npm;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin \App\Models\NpmPackageVersion
+ */
+class NpmPackageVersionResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'name' => $this->npmPackage->name,
+            'version' => $this->version_code,
+            'version_normalized' => $this->normalized_version,
+            'source' => [
+                'type' => 'git',
+                'url' => $this->npmPackage->git_source,
+                'reference' => $this->source_reference,
+            ],
+            'dist' => [
+                'type' => 'tar',
+                'url' => config('app.url') . route(
+                    'npm.npmPackage.npmPackageVersion.download',
+                    [$this->npmPackage, $this],
+                    false,
+                ),
+                'reference' => $this->source_reference,
+                'shasum' => $this->storage_shasum,
+            ],
+            'time' => $this->created_at->toIso8601String(),
+            ...$this->package_json_content,
+        ];
+    }
+}

--- a/app/Models/License.php
+++ b/app/Models/License.php
@@ -5,6 +5,10 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
+use App\Models\ComposerPackage;
+use App\Models\ComposerPackageLicense;
+use App\Models\NpmPackage;
+use App\Models\NpmPackageLicense;
 
 class License extends Authenticatable
 {
@@ -18,5 +22,10 @@ class License extends Authenticatable
     public function composerPackages(): BelongsToMany
     {
         return $this->belongsToMany(ComposerPackage::class)->using(ComposerPackageLicense::class);
+    }
+
+    public function npmPackages(): BelongsToMany
+    {
+        return $this->belongsToMany(NpmPackage::class)->using(NpmPackageLicense::class);
     }
 }

--- a/app/Models/NpmPackage.php
+++ b/app/Models/NpmPackage.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\NpmPackageVersionStatus;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class NpmPackage extends Model
+{
+    use HasFactory;
+
+    public $fillable = [
+        'name',
+        'git_source',
+    ];
+
+    public function npmPackageVersions(): HasMany
+    {
+        return $this->hasMany(NpmPackageVersion::class)
+            ->where('status', '=', NpmPackageVersionStatus::READY);
+    }
+
+    public function licenses(): BelongsToMany
+    {
+        return $this->belongsToMany(License::class)->using(NpmPackageLicense::class);
+    }
+}

--- a/app/Models/NpmPackageLicense.php
+++ b/app/Models/NpmPackageLicense.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Relations\Pivot;
+
+class NpmPackageLicense extends Pivot
+{
+    //
+}

--- a/app/Models/NpmPackageVersion.php
+++ b/app/Models/NpmPackageVersion.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\NpmPackageVersionStatus;
+use App\Enums\NpmPackageVersionType;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Str;
+
+class NpmPackageVersion extends Model
+{
+    use HasFactory;
+
+    public $fillable = [
+        'npm_package_id',
+        'status',
+        'version_code',
+        'version_type',
+        'source_reference',
+        'storage_path',
+        'storage_shasum',
+        'package_json_content',
+    ];
+
+    public $casts = [
+        'status' => NpmPackageVersionStatus::class,
+        'version_type' => NpmPackageVersionType::class,
+        'package_json_content' => 'array',
+    ];
+
+    public function npmPackage(): BelongsTo
+    {
+        return $this->belongsTo(NpmPackage::class);
+    }
+
+    public function normalizedVersion(): Attribute
+    {
+        return Attribute::make(
+            get: fn () => $this->version_type === NpmPackageVersionType::STABLE
+                ? Str::of($this->version_code)
+                    ->replaceMatches('/^v/', '')
+                    ->explode('.')
+                    ->pad(4, '0')
+                    ->implode('.')
+                : $this->version_code,
+        );
+    }
+}

--- a/app/Policies/NpmPackagePolicy.php
+++ b/app/Policies/NpmPackagePolicy.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\NpmPackage;
+use App\Models\License;
+use Illuminate\Auth\Access\Response;
+
+class NpmPackagePolicy
+{
+    public function download(License $license, NpmPackage $npmPackage): Response
+    {
+        return $license->npmPackages()
+            ->where('npm_packages.id', $npmPackage->id)
+            ->exists()
+            ? Response::allow()
+            : Response::deny('You are not allowed to download this package');
+    }
+}

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -36,6 +36,11 @@ class RouteServiceProvider extends ServiceProvider
                 ->name('composer.')
                 ->group(base_path('routes/composer.php'));
 
+            Route::middleware('api')
+                ->prefix('npm')
+                ->name('npm.')
+                ->group(base_path('routes/npm.php'));
+
             Route::middleware('web')
                 ->group(base_path('routes/web.php'));
         });

--- a/database/factories/NpmPackageFactory.php
+++ b/database/factories/NpmPackageFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\NpmPackage>
+ */
+class NpmPackageFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->word . '/' . $this->faker->word,
+            'git_source' => $this->faker->url(),
+        ];
+    }
+}

--- a/database/factories/NpmPackageLicenseFactory.php
+++ b/database/factories/NpmPackageLicenseFactory.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\NpmPackageLicense>
+ */
+class NpmPackageLicenseFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/database/factories/NpmPackageVersionFactory.php
+++ b/database/factories/NpmPackageVersionFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\NpmPackageVersionStatus;
+use App\Models\NpmPackage;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\NpmPackageVersion>
+ */
+class NpmPackageVersionFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'npm_package_id' => NpmPackage::factory(),
+            'version_code' => random_int(0, 5) . '.' . random_int(0, 5) . '.' . random_int(0, 5),
+            'version_type' => $this->faker->randomElement(['dev', 'stable']),
+            'source_reference' => $this->faker->uuid(),
+            'storage_path' => $this->faker->filePath(),
+            'storage_shasum' => $this->faker->sha256(),
+            'package_json_content' => [
+                'name' => $this->faker->word() . '/' . $this->faker->word(),
+            ],
+            'status' => NpmPackageVersionStatus::READY,
+        ];
+    }
+}

--- a/database/migrations/2023_02_20_000000_create_npm_packages_table.php
+++ b/database/migrations/2023_02_20_000000_create_npm_packages_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('npm_packages', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('git_source');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('npm_packages');
+    }
+};

--- a/database/migrations/2023_02_20_000100_create_npm_package_versions_table.php
+++ b/database/migrations/2023_02_20_000100_create_npm_package_versions_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use App\Models\NpmPackage;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('npm_package_versions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignIdFor(NpmPackage::class)->constrained();
+            $table->string('version_code');
+            $table->string('version_type');
+            $table->string('status')->default('draft');
+            $table->string('source_reference');
+            $table->string('storage_path')->nullable();
+            $table->string('storage_shasum')->nullable();
+            $table->json('package_json_content')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('npm_package_versions');
+    }
+};

--- a/database/migrations/2023_02_20_000200_create_npm_package_license_table.php
+++ b/database/migrations/2023_02_20_000200_create_npm_package_license_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('npm_package_license', function (Blueprint $table) {
+            $table->id();
+            $table->foreignIdFor(\App\Models\NpmPackage::class)
+                ->constrained()
+                ->cascadeOnDelete();
+            $table->foreignIdFor(\App\Models\License::class)
+                ->constrained()
+                ->cascadeOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('npm_package_license');
+    }
+};

--- a/routes/npm.php
+++ b/routes/npm.php
@@ -1,0 +1,19 @@
+<?php
+
+use App\Http\Controllers\Npm\NpmPackageController;
+use App\Http\Controllers\Npm\NpmPackageVersionController;
+use App\Http\Controllers\Npm\NpmPackageVersionDownloadController;
+use Illuminate\Support\Facades\Route;
+
+Route::get('/packages.json', [NpmPackageController::class, 'index'])
+    ->name('packages');
+
+Route::get('/npmPackage/{npmPackage:name}{dev?}', [NpmPackageVersionController::class, 'index'])
+    ->name('npmPackage.show')
+    ->where('npmPackage', '([^\/]*\/.[^\/~]*)')
+    ->where('dev', '(~dev)');
+
+Route::get('/npmPackage/{npmPackage:name}/{npmPackageVersion:version_code}/download', NpmPackageVersionDownloadController::class)
+    ->name('npmPackage.npmPackageVersion.download')
+    ->where('npmPackage', '([^\/]*\/.[^\/~]*)')
+    ->middleware('guard:license','auth.basic:license,username', 'can:download,npmPackage');

--- a/tests/Feature/Npm/NpmPackageIndexTest.php
+++ b/tests/Feature/Npm/NpmPackageIndexTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Feature\Npm;
+
+use App\Models\NpmPackage;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Testing\Fluent\AssertableJson;
+use Tests\TestCase;
+
+class NpmPackageIndexTest extends TestCase
+{
+    use WithFaker;
+
+    public function test_the_endpoint_is_public_accessible(): void
+    {
+        $this->getJson(route('npm.packages'))
+            ->assertOk();
+    }
+
+    public function test_the_response_structure_is_good(): void
+    {
+        $this->getJson(route('npm.packages'))
+            ->assertOk()
+            ->assertJson(fn (AssertableJson $json) => $json
+                ->has('packages')
+                ->has('metadata-url')
+                ->has('available-packages')
+            );
+    }
+
+    public function test_the_packages_array_is_always_empty(): void
+    {
+        NpmPackage::factory()->count(5)->create();
+
+        $this->getJson(route('npm.packages'))
+            ->assertOk()
+            ->assertJson(fn (AssertableJson $json) => $json
+                ->where('packages', [])
+                ->etc()
+            );
+    }
+
+    public function test_the_metadata_url_is_correct(): void
+    {
+        $url = $this->faker->url;
+        config(['app.url' => $url]);
+
+        $metadataUrl = $url . route('npm.npmPackage.show', ['%package%'], false);
+
+        $this->getJson(route('npm.packages'))
+            ->assertOk()
+            ->assertJson(fn (AssertableJson $json) => $json
+                ->where('metadata-url', $metadataUrl)
+                ->etc()
+            );
+    }
+
+    public function test_the_available_packages_array_is_correct(): void
+    {
+        $packages = NpmPackage::factory()->count(3)->create();
+
+        $this->getJson(route('npm.packages'))
+            ->assertOk()
+            ->assertJson(fn (AssertableJson $json) => $json
+                ->where('available-packages', $packages->pluck('name')->toArray())
+                ->etc()
+            );
+    }
+}

--- a/tests/Feature/Npm/NpmPackageVersionDownloadTest.php
+++ b/tests/Feature/Npm/NpmPackageVersionDownloadTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Feature\Npm;
+
+use App\Models\NpmPackageVersion;
+use App\Models\License;
+use App\Models\User;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Illuminate\Testing\Fluent\AssertableJson;
+use Tests\TestCase;
+
+class NpmPackageVersionDownloadTest extends TestCase
+{
+    use WithFaker;
+
+    public function test_the_endpoint_is_not_public_accessible(): void
+    {
+        $version = NpmPackageVersion::factory()->create();
+
+        $this->getJson(route('npm.npmPackage.npmPackageVersion.download', [$version->npmPackage, $version]))
+            ->assertUnauthorized()
+            ->assertHeader('WWW-Authenticate', 'Basic');
+    }
+
+    public function test_the_endpoint_can_not_be_accessed_when_user_authentication_is_used(): void
+    {
+        $version = NpmPackageVersion::factory()->create();
+        $user = User::factory()->create();
+
+        $this->withHeaders([
+            'Authorization' => 'Basic ' . base64_encode($user->email . ':password'),
+        ])->getJson(route('npm.npmPackage.npmPackageVersion.download', [$version->npmPackage, $version]))
+            ->assertUnauthorized();
+    }
+
+    public function test_the_endpoint_can_be_accessed_when_license_authentication_is_used_and_the_license_is_linked(): void
+    {
+        $version = NpmPackageVersion::factory()->create();
+        $license = License::factory()->create();
+        $license->npmPackages()->attach($version->npmPackage);
+
+        Storage::shouldReceive('exists')->andReturn(false);
+
+        $this->getJson(route('npm.npmPackage.npmPackageVersion.download', [$version->npmPackage, $version]), [
+            'Authorization' => 'Basic ' . base64_encode($license->username . ':password'),
+        ])->assertNotFound();
+    }
+}

--- a/tests/Feature/Npm/NpmPackageVersionIndexTest.php
+++ b/tests/Feature/Npm/NpmPackageVersionIndexTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Feature\Npm;
+
+use App\Enums\NpmPackageVersionType;
+use App\Models\NpmPackage;
+use App\Models\NpmPackageVersion;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Testing\Fluent\AssertableJson;
+use Tests\TestCase;
+
+class NpmPackageVersionIndexTest extends TestCase
+{
+    use WithFaker;
+
+    public function test_the_endpoint_is_public_accessible(): void
+    {
+        $npmPackage = NpmPackage::factory()->create();
+
+        $this->getJson(route('npm.npmPackage.show', [$npmPackage->name]))
+            ->assertOk();
+    }
+
+    public function test_the_response_structure_is_good(): void
+    {
+        $version = NpmPackageVersion::factory()
+            ->state([
+                'version_type' => NpmPackageVersionType::STABLE,
+                'package_json_content' => ['extra' => 'extra'],
+            ])
+            ->create();
+
+        $this->getJson(route('npm.npmPackage.show', [$version->npmPackage->name]))
+            ->assertOk()
+            ->assertJson(fn (AssertableJson $json) => $json
+                ->has('packages')
+            );
+    }
+
+    public function test_the_versions_are_sorted_on_version_code(): void
+    {
+        $npmPackage = NpmPackage::factory()->create();
+
+        $v1 = NpmPackageVersion::factory()->state([
+                'version_type' => NpmPackageVersionType::STABLE,
+                'version_code' => '1.0.0',
+            ])->for($npmPackage)->create();
+        $v2 = NpmPackageVersion::factory()->state([
+                'version_type' => NpmPackageVersionType::STABLE,
+                'version_code' => '2.0.0',
+            ])->for($npmPackage)->create();
+
+        $this->getJson(route('npm.npmPackage.show', [$npmPackage->name]))
+            ->assertOk()
+            ->assertJson(fn (AssertableJson $json) => $json
+                ->has('packages', fn (AssertableJson $packages) => $packages
+                    ->has($npmPackage->name, fn (AssertableJson $vers) => $vers
+                        ->has('0', fn (AssertableJson $ver) => $ver->where('version', $v2->version_code)->etc())
+                        ->has('1', fn (AssertableJson $ver) => $ver->where('version', $v1->version_code)->etc())
+                    )
+                )
+            );
+    }
+}

--- a/tests/Unit/Policies/NpmPackagePolicyTest.php
+++ b/tests/Unit/Policies/NpmPackagePolicyTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Unit\Policies;
+
+use App\Models\License;
+use App\Models\NpmPackage;
+use App\Policies\NpmPackagePolicy;
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\WithFaker;
+
+class NpmPackagePolicyTest extends TestCase
+{
+    use WithFaker;
+
+    public function test_the_download_method_will_allow_when_the_license_is_linked_to_the_requested_package(): void
+    {
+        $license = License::factory()->create();
+        $npmPackage = NpmPackage::factory()->create();
+        $license->npmPackages()->attach($npmPackage);
+
+        $response = (new NpmPackagePolicy())->download($license, $npmPackage);
+
+        $this->assertTrue($response->allowed());
+    }
+
+    public function test_the_download_method_will_deny_when_the_license_is_linked_to_an_other_package(): void
+    {
+        $license = License::factory()->create();
+        $npmPackage = NpmPackage::factory()->create();
+        $license->npmPackages()->attach($npmPackage);
+
+        $anOtherPackage = NpmPackage::factory()->create();
+
+        $response = (new NpmPackagePolicy())->download($license, $anOtherPackage);
+
+        $this->assertTrue($response->denied());
+    }
+
+    public function test_the_download_method_will_deny_when_the_license_is_not_linked_to_any_package(): void
+    {
+        $license = License::factory()->create();
+        $npmPackage = NpmPackage::factory()->create();
+
+        $response = (new NpmPackagePolicy())->download($license, $npmPackage);
+
+        $this->assertTrue($response->denied());
+    }
+}


### PR DESCRIPTION
## Summary
- add Npm models, controllers, policies, and resources
- register npm routes and provider
- create factories and migrations for npm packages
- implement tests for npm package endpoints and policy

## Testing
- `./vendor/bin/phpunit` *(fails: SQLSTATE[HY000] [2002] Connection refused)*